### PR TITLE
fixes for latest version of Hyprland

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ instructions based on [the official wiki](https://wiki.hyprland.org/Plugins/Usin
 
 **4) prepare the hyprland source for plugin compilation**
 
-`sudo make pluginenv`
+`make all && sudo make installheaders`
 
 **5) cd back and make**
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,8 +89,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     HyprlandAPI::reloadConfig();
 
-    HyprlandAPI::registerCallbackDynamic(PHANDLE, "activeWindow",    [&](void* self, std::any data) { onActiveWindowChange(self, data); });
-    HyprlandAPI::registerCallbackDynamic(PHANDLE, "mouseButton",     [&](void* self, std::any data) { onMouseButton       (self, data); });
+    HyprlandAPI::registerCallbackDynamic(PHANDLE, "activeWindow",    [&](void* self, SCallbackInfo& info, std::any data) { onActiveWindowChange(self, data); });
+    HyprlandAPI::registerCallbackDynamic(PHANDLE, "mouseButton",     [&](void* self, SCallbackInfo& info, std::any data) { onMouseButton       (self, data); });
 
     return {"hyprfocus", "animate windows on focus", "Vortex", "2.0"};
 }


### PR DESCRIPTION
HyprlandAPI::registerCallbackDynamic function signature has changed with the latest commit causing this plugin to fail to build (and previous builds of hyprfocus.so to crash the compositor), updated the params in main.cpp.

also Hyprland's Makefile has been updated and pluginenv has been depricated, updated README.md to reflect latest instructions.